### PR TITLE
Remove libv4l1 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ OBJECTS	:= $(addprefix $(BUILD)/,$(SOURCES:%.c=%.o))
 
 #------------------------------------------------
 
-CFLAGS	:= -Wall -g $(shell pkg-config libv4l1 --cflags)
-LDFLAGS	:= -lc $(shell pkg-config libv4l1 --libs)
+CFLAGS	:= -Wall -g
+LDFLAGS	:= -lc
 
 #------------------------------------------------
 all: $(NAME)


### PR DESCRIPTION
I could be wrong, but libv4l1 doesn't seem to be used.